### PR TITLE
Use API service rather than individual resource modules

### DIFF
--- a/src/api/api-service.js
+++ b/src/api/api-service.js
@@ -1,0 +1,45 @@
+import Vue from 'vue';
+import { EventEmitter } from 'events';
+import { Promise } from 'es6-promise';
+import { ApiCache } from './api-cache.js';
+
+const resourceCache = new ApiCache();
+const apiService = new EventEmitter();
+export default apiService;
+
+const validateFetchParams = (resource, id) => {
+  if (!resource || !id) {
+  	return false;
+  }
+
+  const validResources = {
+  	"": true,
+  	"films": true,
+    "people": true,
+    "planets": true,
+    "species": true,
+    "starships": true,
+    "vehicles": true
+  };
+  return validResources[resource];
+};
+
+apiService.fetch = (resource, id) => {
+  if (validateFetchParams(resource, id)) {
+  	return Promise.resolve('');
+  }
+
+  return new Promise((resolve, reject) => {
+  	const resourceUrl = `${resource}/${id}/`;
+
+  	if (resourceCache.get(resourceUrl)) {
+  	  resolve(resourceCache.get(resourceUrl));
+  	}
+
+  	Vue.http.get(resourceUrl).then(response => {
+  	  const resourceData = response.data;
+  	  resourceCache.put(resourceUrl, resourceData);
+  	  resolve(resourceData);
+  	}, reject);
+  });
+};

--- a/src/api/api-service.js
+++ b/src/api/api-service.js
@@ -7,39 +7,40 @@ const resourceCache = new ApiCache();
 const apiService = new EventEmitter();
 export default apiService;
 
+const validResources = {
+  '': true,
+  films: true,
+  people: true,
+  planets: true,
+  species: true,
+  starships: true,
+  vehicles: true,
+};
+
 const validateFetchParams = (resource, id) => {
   if (!resource || !id) {
-  	return false;
+    return false;
   }
 
-  const validResources = {
-  	"": true,
-  	"films": true,
-    "people": true,
-    "planets": true,
-    "species": true,
-    "starships": true,
-    "vehicles": true
-  };
   return validResources[resource];
 };
 
 apiService.fetch = (resource, id) => {
-  if (validateFetchParams(resource, id)) {
-  	return Promise.resolve('');
+  if (!validateFetchParams(resource, id)) {
+    return Promise.resolve('');
   }
 
   return new Promise((resolve, reject) => {
-  	const resourceUrl = `${resource}/${id}/`;
+    const resourceUrl = `${resource}/${id}/`;
 
-  	if (resourceCache.get(resourceUrl)) {
-  	  resolve(resourceCache.get(resourceUrl));
-  	}
+    if (resourceCache.get(resourceUrl)) {
+      resolve(resourceCache.get(resourceUrl));
+    }
 
-  	Vue.http.get(resourceUrl).then(response => {
-  	  const resourceData = response.data;
-  	  resourceCache.put(resourceUrl, resourceData);
-  	  resolve(resourceData);
-  	}, reject);
+    Vue.http.get(resourceUrl).then(response => {
+      const resourceData = response.data;
+      resourceCache.put(resourceUrl, resourceData);
+      resolve(resourceData);
+    }, reject);
   });
 };

--- a/src/components/ViewPerson.vue
+++ b/src/components/ViewPerson.vue
@@ -23,6 +23,7 @@
 <script>
 import { MdlButton, MdlTextfield, directives } from 'vue-mdl';
 import person from '../api/person';
+import apiService from '../api/api-service';
 
 export default {
   components: {
@@ -53,7 +54,7 @@ export default {
       this.imageShow = false;
       this.personImageMsg = '';
       const randomPersonId = Math.floor((Math.random() * 87) + 1);
-      person.fetch(randomPersonId).then((personData) => {
+      apiService.fetch('people', randomPersonId).then((personData) => {
         this.personData = Object.assign(this.personData, personData);
         person.getPicture(this.personData.name).then((data) => {
           this.loading = false;

--- a/src/components/ViewPlanet.vue
+++ b/src/components/ViewPlanet.vue
@@ -17,7 +17,7 @@
 
 <script>
 import { MdlButton, MdlTextfield, directives } from 'vue-mdl';
-import planet from '../api/planet';
+import apiService from '../api/api-service';
 
 export default {
   components: {
@@ -43,7 +43,7 @@ export default {
   methods: {
     fetchRandomPlanet() {
       const randomPlanetId = Math.floor((Math.random() * 61) + 1);
-      planet.fetch(randomPlanetId).then((planetData) => {
+      apiService.fetch('planets', randomPlanetId).then((planetData) => {
         this.planetData = Object.assign(this.planetData, planetData);
       });
     },

--- a/src/components/ViewStarship.vue
+++ b/src/components/ViewStarship.vue
@@ -21,7 +21,7 @@
 
 <script>
 import { MdlButton, MdlTextfield, directives } from 'vue-mdl';
-import starship from '../api/starship';
+import apiService from '../api/api-service';
 
 export default {
   components: {
@@ -52,7 +52,7 @@ export default {
   methods: {
     fetchRandomStarship() {
       const randomStarshipId = Math.floor((Math.random() * 37) + 1);
-      starship.fetch(randomStarshipId).then((starshipData) => {
+      apiService.fetch('starships', randomStarshipId).then((starshipData) => {
         this.starshipData = Object.assign(this.starshipData, starshipData);
       });
     },

--- a/test/unit/specs/api-service.spec.js
+++ b/test/unit/specs/api-service.spec.js
@@ -1,0 +1,73 @@
+import apiService from 'src/api/api-service';
+
+describe('apiService', () => {
+  var server, responseData;
+
+  before(() => {
+  	server = sinon.fakeServer.create();
+  	server.autoRespond = true;
+  	server.respondWith('GET', 'people/1/', '{"name":"Luke Skywalker","height":"172","mass":"77","hair_color":"blond", \
+  	  "skin_color":"fair","eye_color":"blue","birth_year":"19BBY","gender":"male"}');
+  	responseData = {"name":"Luke Skywalker","height":"172","mass":"77","hair_color":"blond","skin_color":"fair",
+  	  "eye_color":"blue","birth_year":"19BBY","gender":"male"};
+  });
+
+  after(() => {
+  	server.restore();
+  });
+
+  describe('fetch()', () => {
+  	it('returns an empty string if resource is not passed', () => {
+  	  const promise = apiService.fetch('', 1);
+  	  promise.then(result => {
+  	  	expect(result).toBe('');
+  	  }, () => {
+  	  	expect('promise').toBe('not to be rejected');
+  	  });
+  	});
+
+  	it('returns an empty string if id is not passed', () => {
+  	  const promise = apiService.fetch('people', '');
+  	  promise.then(result => {
+  	  	expect(result).toBe('');
+  	  }, () => {
+  	  	expect('promise').toBe('not to be rejected');
+  	  });
+  	});
+
+  	it('returns an empty string for an invalid resource', () => {
+  	  const promise = apiService.fetch('badresource', 1);
+  	  promise.then(result => {
+  	  	expect(result).toBe('');
+  	  }, () => {
+  	  	expect('promise').toBe('not to be rejected');
+  	  });
+  	});
+
+  	it('should call the API to get the data', () => {
+  	  const promise = apiService.fetch('people', 1);
+  	  promise.then(result => {
+  	  	expect(result).toEqual(responseData);
+  	  }, () => {
+  	  	expect('promise').toBe('not to be rejected');
+  	  });
+  	});
+
+  	it('should get data from the cache if possible', () => {
+  	  server.autoRespond = false;
+
+  	  const firstPromise = apiService.fetch('people', 1);
+  	  firstPromise.then(result => {
+  	  	assert(result).toEqual(responseData);
+  	  });
+  	  server.respond();
+
+  	  const secondPromise = apiService.fetch('people', 1);
+  	  secondPromise.then(result => {
+  	  	assert(result).toEqual(responseData);
+  	  });
+
+  	  server.autoRespond = true;
+  	})
+  });
+});

--- a/test/unit/specs/api-service.spec.js
+++ b/test/unit/specs/api-service.spec.js
@@ -1,73 +1,73 @@
 import apiService from 'src/api/api-service';
 
 describe('apiService', () => {
-  var server, responseData;
+  const server = sinon.fakeServer.create();
+  const responseData = { name: 'Luke Skywalker', height: '172', mass: '77', hair_color: 'blond',
+    skin_color: 'fair', eye_color: 'blue', birth_year: '19BBY', gender: 'male' };
 
   before(() => {
-  	server = sinon.fakeServer.create();
-  	server.autoRespond = true;
-  	server.respondWith('GET', 'people/1/', '{"name":"Luke Skywalker","height":"172","mass":"77","hair_color":"blond", \
-  	  "skin_color":"fair","eye_color":"blue","birth_year":"19BBY","gender":"male"}');
-  	responseData = {"name":"Luke Skywalker","height":"172","mass":"77","hair_color":"blond","skin_color":"fair",
-  	  "eye_color":"blue","birth_year":"19BBY","gender":"male"};
+    server.autoRespond = true;
+    server.respondWith('GET', 'people/1/',
+      '{"name":"Luke Skywalker","height":"172","mass":"77","hair_color":"blond",' +
+      '"skin_color":"fair","eye_color":"blue","birth_year":"19BBY","gender":"male"}');
   });
 
   after(() => {
-  	server.restore();
+    server.restore();
   });
 
   describe('fetch()', () => {
-  	it('returns an empty string if resource is not passed', () => {
-  	  const promise = apiService.fetch('', 1);
-  	  promise.then(result => {
-  	  	expect(result).toBe('');
-  	  }, () => {
-  	  	expect('promise').toBe('not to be rejected');
-  	  });
-  	});
+    it('returns an empty string if resource is not passed', () => {
+      const promise = apiService.fetch('', 1);
+      promise.then(result => {
+        expect(result).toBe('');
+      }, () => {
+        expect('promise').toBe('not to be rejected');
+      });
+    });
 
-  	it('returns an empty string if id is not passed', () => {
-  	  const promise = apiService.fetch('people', '');
-  	  promise.then(result => {
-  	  	expect(result).toBe('');
-  	  }, () => {
-  	  	expect('promise').toBe('not to be rejected');
-  	  });
-  	});
+    it('returns an empty string if id is not passed', () => {
+      const promise = apiService.fetch('people', '');
+      promise.then(result => {
+        expect(result).toBe('');
+      }, () => {
+        expect('promise').toBe('not to be rejected');
+      });
+    });
 
-  	it('returns an empty string for an invalid resource', () => {
-  	  const promise = apiService.fetch('badresource', 1);
-  	  promise.then(result => {
-  	  	expect(result).toBe('');
-  	  }, () => {
-  	  	expect('promise').toBe('not to be rejected');
-  	  });
-  	});
+    it('returns an empty string for an invalid resource', () => {
+      const promise = apiService.fetch('badresource', 1);
+      promise.then(result => {
+        expect(result).toBe('');
+      }, () => {
+        expect('promise').toBe('not to be rejected');
+      });
+    });
 
-  	it('should call the API to get the data', () => {
-  	  const promise = apiService.fetch('people', 1);
-  	  promise.then(result => {
-  	  	expect(result).toEqual(responseData);
-  	  }, () => {
-  	  	expect('promise').toBe('not to be rejected');
-  	  });
-  	});
+    it('should call the API to get the correct data', () => {
+      const promise = apiService.fetch('people', 1);
+      promise.then(result => {
+        expect(result).toEqual(responseData);
+      }, () => {
+        expect('promise').toBe('not to be rejected');
+      });
+    });
 
-  	it('should get data from the cache if possible', () => {
-  	  server.autoRespond = false;
+    it('should get data from the cache if possible', () => {
+      server.autoRespond = false;
 
-  	  const firstPromise = apiService.fetch('people', 1);
-  	  firstPromise.then(result => {
-  	  	assert(result).toEqual(responseData);
-  	  });
-  	  server.respond();
+      const firstPromise = apiService.fetch('people', 1);
+      firstPromise.then(result => {
+        expect(result).toEqual(responseData);
+      });
+      server.respond();
 
-  	  const secondPromise = apiService.fetch('people', 1);
-  	  secondPromise.then(result => {
-  	  	assert(result).toEqual(responseData);
-  	  });
+      const secondPromise = apiService.fetch('people', 1);
+      secondPromise.then(result => {
+        expect(result).toEqual(responseData);
+      });
 
-  	  server.autoRespond = true;
-  	})
+      server.autoRespond = true;
+    });
   });
 });


### PR DESCRIPTION
This change includes an api-service module that provides a generic fetch function for any resource in the SWAPI, rather than requiring consumers to use a resource-specific module. Fix for [issue #19](https://github.com/alexkramer/force-vue/issues/19).
