### PR TITLE
Issue #51 - Adds Image API Grab for all existing views

### DIFF
--- a/src/api/person.js
+++ b/src/api/person.js
@@ -4,7 +4,6 @@ import { Promise } from 'es6-promise';
 import { ApiCache } from './api-cache.js';
 
 const personCache = new ApiCache();
-const pictureCache = Object.create(null);
 const person = new EventEmitter();
 const personBaseUrl = 'people/';
 export default person;
@@ -23,37 +22,6 @@ person.fetch = id => {
       const personData = response.data;
       personCache.put(personToGet, personData);
       resolve(personData);
-    }, reject);
-  });
-};
-
-person.getPicture = searchWord => {
-  if (!searchWord) {
-    return Promise.resolve('');
-  }
-  return new Promise((resolve, reject) => {
-    if (pictureCache[searchWord]) {
-      resolve(pictureCache[searchWord]);
-    }
-    const param = {
-      q: searchWord,
-      q_type: 'jpg',
-    };
-    Vue.http.headers.common.Authorization = '';
-    Vue.http.get(process.env.IMAGE_HOST, param, {
-      headers: {
-        Authorization: process.env.IMGUR_CLIENT_ID,
-      },
-    }).then(response => {
-      let imgUrl = null;
-      if (typeof response.data === 'undefined' || typeof response.data.data[0] === 'undefined') {
-        imgUrl = null;
-      } else if (typeof response.data.data[0].cover !== 'undefined') {
-        imgUrl = 'http://i.imgur.com/'.concat(response.data.data[0].cover, 'm.jpg');
-      } else if (typeof response.data.data[0].link !== 'undefined') {
-        imgUrl = response.data.data[0].link.replace(/\.jpg$/, 'm.jpg');
-      }
-      resolve(imgUrl);
     }, reject);
   });
 };

--- a/src/api/picture.js
+++ b/src/api/picture.js
@@ -1,0 +1,38 @@
+import Vue from 'vue';
+import { EventEmitter } from 'events';
+import { Promise } from 'es6-promise';
+
+const picture = new EventEmitter();
+const pictureCache = Object.create(null);
+export default picture;
+
+picture.getPicture = searchWord => {
+  if (!searchWord) {
+    return Promise.resolve('');
+  }
+  return new Promise((resolve, reject) => {
+    if (pictureCache[searchWord]) {
+      resolve(pictureCache[searchWord]);
+    }
+    const param = {
+      q: searchWord,
+      q_type: 'jpg',
+    };
+    Vue.http.headers.common.Authorization = '';
+    Vue.http.get(process.env.IMAGE_HOST, param, {
+      headers: {
+        Authorization: process.env.IMGUR_CLIENT_ID,
+      },
+    }).then(response => {
+      let imgUrl = null;
+      if (typeof response.data === 'undefined' || typeof response.data.data[0] === 'undefined') {
+        imgUrl = null;
+      } else if (typeof response.data.data[0].cover !== 'undefined') {
+        imgUrl = 'http://i.imgur.com/'.concat(response.data.data[0].cover, 'm.jpg');
+      } else if (typeof response.data.data[0].link !== 'undefined') {
+        imgUrl = response.data.data[0].link.replace(/\.jpg$/, 'm.jpg');
+      }
+      resolve(imgUrl);
+    }, reject);
+  });
+};

--- a/src/api/planet.js
+++ b/src/api/planet.js
@@ -5,6 +5,7 @@ import { Promise } from 'es6-promise';
 import { ApiCache } from './api-cache.js';
 
 const planetCache = new ApiCache();
+const pictureCache = Object.create(null);
 const planet = new EventEmitter();
 const planetBaseUrl = 'planets/';
 export default planet;
@@ -23,6 +24,38 @@ planet.fetch = id => {
       const planetData = response.data;
       planetCache.put(planetToGet, planetData);
       resolve(planetData);
+    }, reject);
+  });
+};
+
+
+planet.getPicture = searchWord => {
+  if (!searchWord) {
+    return Promise.resolve('');
+  }
+  return new Promise((resolve, reject) => {
+    if (pictureCache[searchWord]) {
+      resolve(pictureCache[searchWord]);
+    }
+    const param = {
+      q: searchWord,
+      q_type: 'jpg',
+    };
+    Vue.http.headers.common.Authorization = '';
+    Vue.http.get(process.env.IMAGE_HOST, param, {
+      headers: {
+        Authorization: process.env.IMGUR_CLIENT_ID,
+      },
+    }).then(response => {
+      let imgUrl = null;
+      if (typeof response.data === 'undefined' || typeof response.data.data[0] === 'undefined') {
+        imgUrl = null;
+      } else if (typeof response.data.data[0].cover !== 'undefined') {
+        imgUrl = 'http://i.imgur.com/'.concat(response.data.data[0].cover, 'm.jpg');
+      } else if (typeof response.data.data[0].link !== 'undefined') {
+        imgUrl = response.data.data[0].link.replace(/\.jpg$/, 'm.jpg');
+      }
+      resolve(imgUrl);
     }, reject);
   });
 };

--- a/src/api/planet.js
+++ b/src/api/planet.js
@@ -5,7 +5,6 @@ import { Promise } from 'es6-promise';
 import { ApiCache } from './api-cache.js';
 
 const planetCache = new ApiCache();
-const pictureCache = Object.create(null);
 const planet = new EventEmitter();
 const planetBaseUrl = 'planets/';
 export default planet;
@@ -24,38 +23,6 @@ planet.fetch = id => {
       const planetData = response.data;
       planetCache.put(planetToGet, planetData);
       resolve(planetData);
-    }, reject);
-  });
-};
-
-
-planet.getPicture = searchWord => {
-  if (!searchWord) {
-    return Promise.resolve('');
-  }
-  return new Promise((resolve, reject) => {
-    if (pictureCache[searchWord]) {
-      resolve(pictureCache[searchWord]);
-    }
-    const param = {
-      q: searchWord,
-      q_type: 'jpg',
-    };
-    Vue.http.headers.common.Authorization = '';
-    Vue.http.get(process.env.IMAGE_HOST, param, {
-      headers: {
-        Authorization: process.env.IMGUR_CLIENT_ID,
-      },
-    }).then(response => {
-      let imgUrl = null;
-      if (typeof response.data === 'undefined' || typeof response.data.data[0] === 'undefined') {
-        imgUrl = null;
-      } else if (typeof response.data.data[0].cover !== 'undefined') {
-        imgUrl = 'http://i.imgur.com/'.concat(response.data.data[0].cover, 'm.jpg');
-      } else if (typeof response.data.data[0].link !== 'undefined') {
-        imgUrl = response.data.data[0].link.replace(/\.jpg$/, 'm.jpg');
-      }
-      resolve(imgUrl);
     }, reject);
   });
 };

--- a/src/components/ViewPerson.vue
+++ b/src/components/ViewPerson.vue
@@ -23,6 +23,7 @@
 <script>
 import { MdlButton, MdlTextfield, directives } from 'vue-mdl';
 import person from '../api/person';
+import picture from '../api/picture';
 
 export default {
   components: {
@@ -55,14 +56,14 @@ export default {
       const randomPersonId = Math.floor((Math.random() * 87) + 1);
       person.fetch(randomPersonId).then((personData) => {
         this.personData = Object.assign(this.personData, personData);
-        person.getPicture(this.personData.name).then((data) => {
+        picture.getPicture(this.personData.name).then((data) => {
           this.loading = false;
           if (data) {
             this.personImage = data;
             this.imageShow = true;
           } else {
             this.personImage = '';
-            this.personImageMsg = 'No image found.';
+            this.personImageMsg = `No image found for ${this.personData.name}`;
           }
         });
       });
@@ -77,7 +78,7 @@ h1 {
   color: black;
 }
 figure img {
-  width: 285px;
+  width: 100%;
 }
 .mdl-card__media {
   background-color: #FFF;

--- a/src/components/ViewPlanet.vue
+++ b/src/components/ViewPlanet.vue
@@ -25,6 +25,7 @@
 <script>
 import { MdlButton, MdlTextfield, directives } from 'vue-mdl';
 import planet from '../api/planet';
+import picture from '../api/picture';
 
 export default {
   components: {
@@ -60,14 +61,14 @@ export default {
       const randomPlanetId = Math.floor((Math.random() * 61) + 1);
       planet.fetch(randomPlanetId).then((planetData) => {
         this.planetData = Object.assign(this.planetData, planetData);
-        planet.getPicture(this.planetData.name).then((data) => {
+        picture.getPicture(this.planetData.name).then((data) => {
           this.loading = false;
           if (data) {
             this.planetImage = data;
             this.imageShow = true;
           } else {
             this.planetImage = '';
-            this.planetImageMsg = 'No image found.';
+            this.planetImageMsg = `No image found for ${this.planetData.name}`;
           }
         });
       });
@@ -82,7 +83,7 @@ h1 {
   color: black;
 }
 figure img {
-  width: 285px;
+  width: 100%;
 }
 .mdl-card__media {
   background-color: #FFF;

--- a/src/components/ViewPlanet.vue
+++ b/src/components/ViewPlanet.vue
@@ -13,6 +13,13 @@
     <mdl-textfield data-qa="surfaceWaterTextbox" floating-label="Surface Water" :value.sync="planetData.surface_water"></mdl-textfield>
     <mdl-textfield data-qa="populationTextbox" floating-label="Population" :value.sync="planetData.population"></mdl-textfield>
   </div>
+  <div class="mdl-cell mdl-card mdl-shadow--4dp">
+    <figure class="mdl-card__media">
+      <div v-show="loading" class="mdl-spinner mdl-spinner--single-color mdl-js-spinner is-active"></div>
+      <img v-show="imageShow" :src.sync="planetImage">
+      <span>{{planetImageMsg}}</span>
+    </figure>
+  </div>
 </template>
 
 <script>
@@ -38,15 +45,46 @@ export default {
         surface_water: '',
         population: '',
       },
+      planetImage: '',
+      planetImageMsg: '',
+      imageShow: false,
+      loading: false,
     };
   },
   methods: {
     fetchRandomPlanet() {
+      this.loading = true;
+      this.imageShow = false;
+      this.planetImageMsg = '';
+      this.planetImage = '';
       const randomPlanetId = Math.floor((Math.random() * 61) + 1);
       planet.fetch(randomPlanetId).then((planetData) => {
         this.planetData = Object.assign(this.planetData, planetData);
+        planet.getPicture(this.planetData.name).then((data) => {
+          this.loading = false;
+          if (data) {
+            this.planetImage = data;
+            this.imageShow = true;
+          } else {
+            this.planetImage = '';
+            this.planetImageMsg = 'No image found.';
+          }
+        });
       });
     },
   },
 };
 </script>
+
+
+<style scoped>
+h1 {
+  color: black;
+}
+figure img {
+  width: 285px;
+}
+.mdl-card__media {
+  background-color: #FFF;
+}
+</style>

--- a/src/components/ViewStarship.vue
+++ b/src/components/ViewStarship.vue
@@ -17,11 +17,19 @@
     <mdl-textfield data-qa="mgltTextbox" floating-label="MGLT" :value.sync="starshipData.MGLT"></mdl-textfield>
     <mdl-textfield data-qa="starshipClassTextbox" floating-label="Starship Class" :value.sync="starshipData.starship_class"></mdl-textfield>
   </div>
+  <div class="mdl-cell mdl-card mdl-shadow--4dp">
+    <figure class="mdl-card__media">
+      <div v-show="loading" class="mdl-spinner mdl-spinner--single-color mdl-js-spinner is-active"></div>
+      <img v-show="imageShow" :src.sync="starshipImage">
+      <span>{{starshipImageMsg}}</span>
+    </figure>
+  </div>
 </template>
 
 <script>
 import { MdlButton, MdlTextfield, directives } from 'vue-mdl';
 import starship from '../api/starship';
+import picture from '../api/picture';
 
 export default {
   components: {
@@ -47,6 +55,10 @@ export default {
         starship_class: '',
         pilots: '',
       },
+      starshipImage: '',
+      starshipImageMsg: '',
+      imageShow: false,
+      loading: false,
     };
   },
   methods: {
@@ -54,8 +66,30 @@ export default {
       const randomStarshipId = Math.floor((Math.random() * 37) + 1);
       starship.fetch(randomStarshipId).then((starshipData) => {
         this.starshipData = Object.assign(this.starshipData, starshipData);
+        picture.getPicture(this.starshipData.name).then((data) => {
+          this.loading = false;
+          if (data) {
+            this.starshipImage = data;
+            this.imageShow = true;
+          } else {
+            this.starshipImage = '';
+            this.starshipImageMsg = `No image found for ${this.starshipData.name}`;
+          }
+        });
       });
     },
   },
 };
 </script>
+
+<style scoped>
+h1 {
+  color: black;
+}
+figure img {
+  width: 100%;
+}
+.mdl-card__media {
+  background-color: #FFF;
+}
+</style>


### PR DESCRIPTION
This code change implements the Image API load for all existing views.
- creates new `picture` API object for retrieving a photo given a search word (generally, the `object.name` property)
- integrates `picture` API into Person, Planet, and Starship view loading, as part of the promise chain
- adds picture containers to Planet and Starship pages, based on Person picture
- updates 'No image found' text to be templated based on search term, example: "No image found for Mos Eisley"
- updates image CSS to fill the fluid container width

Existing application patterns were followed in templates and javascript. Layout changes are beyond the scope of this issue, and so were not attempted.

Note: 'Vehicle' views were not found within the repository, and as such have not been updated with photos. However, the new Picture API added in this update can be easily integrated into Vehicle views, or any other views in the future, satisfying #51.
